### PR TITLE
Better error handling in requestCallback

### DIFF
--- a/lib/fitbit_client.js
+++ b/lib/fitbit_client.js
@@ -26,11 +26,11 @@ module.exports = function (api_key, api_secret, callbackURI) {
     function requestCallback(callback) {
       return function (err, data, response) {
         if (err) return callback(err, data);
+        var exception = null;
         try {
-          callback(null, response, JSON.parse(data));
-        } catch (exc) {
-          callback(exc, response, data);
-        }
+          data = JSON.parse(data);
+        } catch (e) { exception = e; }
+        callback(exception, response, data);
       };
     }
 


### PR DESCRIPTION
If an exception happened inside the callback, it was caught by the catch outside the callback, and then the error was sent to the callback. Brainmelt. :P I've fixed it so that it only catches the parsing errors.
