### PR TITLE
Install middleware separately to fix runtime error

### DIFF
--- a/example/test.js
+++ b/example/test.js
@@ -1,8 +1,10 @@
 var express = require('express');
+var bodyParser = require('body-parser')
+var cookieParser = require('cookie-parser')
 
 var app = express();
-app.use(express.bodyParser());
-app.use(express.cookieParser('sess'));
+app.use(bodyParser());
+app.use(cookieParser('sess'));
 
 var PORT = process.argv[5] || 8553;
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "serializer": ">=0.0.2 <0.1.0"
   },
   "devDependencies": {
+    "body-parser": "^1.13.2",
+    "cookie-parser": "^1.3.5",
     "express":">= 3.0.0"
   },
   "repository" : {


### PR DESCRIPTION
Error: Most middleware (like bodyParser) is no longer bundled with
Express and must be installed separately. Please see
https://github.com/senchalabs/connect#middleware.
